### PR TITLE
Delphi Berlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __history
 *.exe
 *.dll
 bin/*
+demo/__recovery/

--- a/OSCUtils.pas
+++ b/OSCUtils.pas
@@ -168,7 +168,7 @@ begin
   intg := htonl(intg);
   {$ENDIF}
 
-  Result := IdGlobal.RawToBytes(intg, SizeOf(intg));
+  Result := TBytes(IdGlobal.RawToBytes(intg, SizeOf(intg)));
 end;
 
 function MakeOSCInt(value: Integer): TBytes;
@@ -178,7 +178,7 @@ begin
   {$ELSE}
   value := htonl(value);
   {$ENDIF}
-  Result := IdGlobal.RawToBytes(value, SizeOf(value));
+  Result := TBytes(IdGlobal.RawToBytes(value, SizeOf(value)));
 end;
 
 function MakeOSCString(value: String): TBytes;
@@ -213,7 +213,7 @@ begin
     Inc(off);
   // Retrieve the string.
   SetLength(Result, off - Offset);
-  IdGlobal.CopyTIdBytes(Bytes, Offset, Result, 0, Length(Result));
+  Move(Bytes[Offset], Result[0], Length(Result));
   // Increase the offset by a multiple of 4.
   Offset := off + (4 - off mod 4);
 end;

--- a/demo/Main.pas
+++ b/demo/Main.pas
@@ -4,7 +4,7 @@ interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, IdSocketHandle, IdUDPServer,
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, IdSocketHandle, IdUDPServer, IdGlobal,
   IdBaseComponent, IdComponent, IdUDPBase, IdUDPClient, Vcl.StdCtrls;
 
 type
@@ -23,7 +23,7 @@ type
     SendArgumentsEdit: TEdit;
     SendButton: TButton;
     procedure FUDPServerUDPRead(AThread: TIdUDPListenerThread; AData:
-        TArray<System.Byte>; ABinding: TIdSocketHandle);
+        TIdBytes; ABinding: TIdSocketHandle);
     procedure SendButtonClick(Sender: TObject);
   private
     { Private declarations }
@@ -41,16 +41,16 @@ uses OSCUtils;
 {$R *.dfm}
 
 procedure TForm1.FUDPServerUDPRead(AThread: TIdUDPListenerThread; AData:
-    TArray<System.Byte>; ABinding: TIdSocketHandle);
+    TIdBytes; ABinding: TIdSocketHandle);
 var
-  packet: TOSCPacket;
-  msg: TOSCMessage;
-  i: Integer;
-  typetag, arg: String;
+  packet        : TOSCPacket;
+  msg           : TOSCMessage;
+  i             : Integer;
+  typetag, arg  : String;
   formatSettings: TFormatSettings;
 begin
-  packet := TOSCpacket.Unpack(AData, Length(AData));
-  msg := packet.MatchAddress(ReceiveAddressEdit.Text);
+  packet := TOSCPacket.Unpack(TBytes(AData), Length(AData));
+  msg    := packet.MatchAddress(ReceiveAddressEdit.Text);
   if Assigned(msg) then
   begin
     msg.Decode;
@@ -76,23 +76,23 @@ end;
 
 procedure TForm1.SendButtonClick(Sender: TObject);
 var
-  msg: TOSCMessage;
+  msg   : TOSCMessage;
   bundle: TOSCBundle;
 begin
-  //create a bundle
+  // create a bundle
   bundle := TOSCBundle.Create(nil);
 
-  //create a message
+  // create a message
   msg := TOSCMessage.Create(SendAddressEdit.Text);
 
-  //add arguments to the message
+  // add arguments to the message
   msg.AddString(SendArgumentsEdit.Text);
 
-  //add message to the bundle
+  // add message to the bundle
   bundle.Add(msg);
 
-  //send bundle as bytes
-  FUDPClient.SendBuffer(bundle.ToOSCBytes);
+  // send bundle as bytes
+  FUDPClient.SendBuffer(TIdBytes(bundle.ToOSCBytes));
 end;
 
 end.


### PR DESCRIPTION
Indy switched to using TIdBytes to store and pass data, causing incompatibilities in newer Delphi versions. 

Some notes:

- This version compiles with XE7 and 10.1/Berlin. This probably breaks compatibility with older Delphi (well, Indy) versions.  I don't know when this changed.

- Delphi doesn't like conditional defines in the form class, and the incompatible event handler parameter list requires something like that. So either code needs to be rewritten in another way, or duplicated. I don't see an easy/clean/elegant solution. But in general I'd say that it's better to support newer Delphi's rather than older.... 